### PR TITLE
Set SPI clock to FCPU div 2

### DIFF
--- a/Mirf/MirfHardwareSpiDriver.h
+++ b/Mirf/MirfHardwareSpiDriver.h
@@ -15,7 +15,7 @@ class MirfHardwareSpiDriver : public MirfSpiDriver {
 		void begin() {
 			SPI.begin();
 			SPI.setDataMode(SPI_MODE0);
-			SPI.setClockDivider(SPI_2XCLOCK_MASK);
+			SPI.setClockDivider(SPI_CLOCK_DIV2);
 		}
 
 		void end() {


### PR DESCRIPTION
Hi,
I noticed that MirfHardwareSpiDriver sets SPI clock to FCPU div 16, which is quite slow. Someone used SPI_2XCLOCK_MASK as clock divider value, probably by mistake, because SPI_CLOCK_DIV**\* values should be used. I chose SPI_CLOCK_DIV2 value, which sets the clock to 8MHz on 16 MHz Arduino, which works fine for me. Alternatively, slower clock could be used if desired (SPI_CLOCK_DIV4).
